### PR TITLE
PHP 8.4 Compatibility: Mark all nullable parameters as such

### DIFF
--- a/src/Entities/BancontactPayment.php
+++ b/src/Entities/BancontactPayment.php
@@ -24,7 +24,7 @@ class BancontactPayment extends Payment
      * @param string $purchaseId
      * @param \DateTime $expiryDate
      */
-    public function __construct(Money $money, $purchaseId, \DateTime $expiryDate = null)
+    public function __construct(Money $money, $purchaseId, ?\DateTime $expiryDate = null)
     {
         parent::__construct($money, 'Bancontact', $purchaseId);
 

--- a/src/Entities/Charge.php
+++ b/src/Entities/Charge.php
@@ -28,7 +28,7 @@ class Charge
      * @param Money $money
      * @param array|null $payments
      */
-    public function __construct(Money $money, array $payments = null)
+    public function __construct(Money $money, ?array $payments = null)
     {
         $this->money = $money;
         $this->payments = $payments ? $payments : [];

--- a/src/Entities/CreditCardPayment.php
+++ b/src/Entities/CreditCardPayment.php
@@ -28,7 +28,7 @@ class CreditCardPayment extends Payment
      * @param string $purchaseId
      * @param \DateTime $dueDate
      */
-    public function __construct(Money $money, array $issuers, $purchaseId, \DateTime $dueDate = null)
+    public function __construct(Money $money, array $issuers, $purchaseId, ?\DateTime $dueDate = null)
     {
         parent::__construct($money, 'Creditcard', $purchaseId);
 

--- a/src/Entities/WireTransferPayment.php
+++ b/src/Entities/WireTransferPayment.php
@@ -24,7 +24,7 @@ class WireTransferPayment extends Payment
      * @param string $purchaseId
      * @param \DateTime $expiryDate
      */
-    public function __construct(Money $money, $purchaseId, \DateTime $expiryDate = null)
+    public function __construct(Money $money, $purchaseId, ?\DateTime $expiryDate = null)
     {
         parent::__construct($money, 'WireTransfer', $purchaseId);
 

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -30,7 +30,7 @@ class Gateway
      * @param Credentials $credentials
      * @param HttpClient|null $httpClient
      */
-    public function __construct(Credentials $credentials, HttpClient $httpClient = null)
+    public function __construct(Credentials $credentials, ?HttpClient $httpClient = null)
     {
         if (!$httpClient) {
             $httpClient = new HttpClient([


### PR DESCRIPTION
PHP 8.4 deprecated implicitly nullable parameter types: https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter

This fixes the "Implicitly marking parameter _{parameter name}_ as nullable is deprecated, the explicit nullable type must be used instead" error.